### PR TITLE
Add the global PR template and initialise the readme file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Description
+
+
+
+## Context (JIRA ticket)
+
+
+
+## How has this been tested
+
+
+
+## Type of change
+
+<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->
+
+- [ ] bug fix
+- [ ] new feature
+- [ ] modification
+- [ ] breaking change
+- [ ] non-functional
+
+## Checklist
+
+<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->
+
+- [ ] I have added tests to cover my changes
+- [ ] Existing tests pass
+- [ ] Docs updated (where applicable)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# .github
+# Firefly Trading Labs' .github repository
+
+This repository is to be used for any shared functionality that is required for operating within GitHub.
+
+## Pull Request template
+
+The default pull request template is setup in `.github/pull_request_template.md`.


### PR DESCRIPTION
## Description

Adds the global PR template to the shared content repository and initialises the readme file

## Context (JIRA ticket)

[TL-5436](https://raidllp.atlassian.net/browse/TL-5436)

## How has this been tested

Is a documentation PR

## Type of change

<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->

- [ ] bug fix
- [ ] new feature
- [ ] modification
- [ ] breaking change
- [x] non-functional

## Checklist

<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->

- [ ] I have added tests to cover my changes
- [x] Existing tests pass
- [x] Docs updated (where applicable)

