### PR TITLE
Add a couple of shared workflows for dotnet

### DIFF
--- a/.github/workflows/dotnet-publish-package.yaml
+++ b/.github/workflows/dotnet-publish-package.yaml
@@ -1,0 +1,40 @@
+name: Publish a NuGet package to MyGet
+on:
+  workflow_call:
+    inputs:
+      project:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+    secrets:
+      MYGETTOKEN:
+        required: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.x
+      - name: Add MyGet repository
+        run: dotnet nuget add source https://www.myget.org/F/fireflybackbone/api/v3/index.json -n firefly-backbone -u fireflybackbone --store-password-in-clear-text -p "$MYGETTOKEN"
+        env:
+          MYGETTOKEN: ${{secrets.MYGETTOKEN}}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget
+      - name: Build the project
+        run: dotnet build --configuration Release ${{inputs.project}}
+      - name: Create the package
+        run: dotnet pack --no-build --configuration Release ${{inputs.project}} /p:Version=${{inputs.version}}
+      - name: Publish to MyGet
+        run: dotnet nuget push ${{inputs.project}}/bin/Release/*.nupkg --source https://www.myget.org/F/fireflybackbone/api/v2/package -k "$MYGETTOKEN"
+        env:
+          MYGETTOKEN: ${{secrets.MYGETTOKEN}}

--- a/.github/workflows/dotnet-tests.yaml
+++ b/.github/workflows/dotnet-tests.yaml
@@ -1,0 +1,45 @@
+name: Run Unit Tests
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        required: true
+        type: string
+      test-project:
+        required: true
+        type: string
+    secrets:
+      MYGETTOKEN:
+        required: true
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.x
+      - name: Add MyGet repository
+        run: dotnet nuget add source https://www.myget.org/F/fireflybackbone/api/v3/index.json -n firefly-backbone -u fireflybackbone --store-password-in-clear-text -p "$MYGETTOKEN"
+        env:
+          MYGETTOKEN: ${{secrets.MYGETTOKEN}}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget
+      - name: Install Dependencies
+        run: dotnet restore ${{ inputs.test-project }}
+      - name: Run Tests
+        run: dotnet test --logger trx --results-directory results-${{ inputs.project-name }} ${{ inputs.test-project }}
+      - name: Upload Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ inputs.project-name }}
+          path: results-${{ inputs.project-name }}
+        if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,74 @@ This repository is to be used for any shared functionality that is required for 
 ## Pull Request template
 
 The default pull request template is setup in `.github/pull_request_template.md`.
+
+## Recommended GitHub Action triggers
+
+> We recommend adding the `workflow_dispatch` trigger to every action to allow it to be manually run
+
+### For unit tests
+
+For running unit tests, set up a trigger to run the tests when either the test project changes and any of it's dependencies
+
+```yaml
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - path/to/Some.Project/**
+      - path/to/Some.Project.Tests/**
+      - path/to/Some.Dependency/**
+      - '!**.md' # so that changes to documentation don't trigger tests
+  workflow_dispatch:
+```
+
+### For publishing packages or services
+
+For publishing packages or services, set up a trigger to be when a release is published
+
+```yaml
+on:
+  release:
+    types: 
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+```
+
+## Shared GitHub Action workflows
+
+> Always use forward slashes for paths! These actions run on linux
+
+### Running dotnet tests
+
+To use the shared workflow for running dotnet tests, use the following job
+
+```yaml
+jobs:
+  test:
+    uses: firefly-trading-labs/.github/.github/workflows/tests.yaml@main
+    with: 
+      project-name: Some.Project.Tests
+      test-project: path/to/Some.Project.Tests/Some.Project.Tests.csproj
+    secrets:
+      MYGETTOKEN: ${{secrets.MYGETTOKEN}}
+```
+
+### Publishing dotnet packages to MyGet
+
+To use the shared workflow for publishing dotnet packages to MyGet, use the following job
+
+```yaml
+jobs:
+  publish:
+    uses: firefly-trading-labs/.github/.github/workflows/publish-package.yaml@main
+    with: 
+      project: path/to/Some.Project
+      version: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.release.tag_name }}
+    secrets:
+      MYGETTOKEN: ${{secrets.MYGETTOKEN}}
+```


### PR DESCRIPTION
## Description

Add the shared workflows for publishing `dotnet` packages to MyGet and running `dotnet` unit tests

## Context (JIRA ticket)

[TL-5437](https://raidllp.atlassian.net/browse/TL-5437)

## How has this been tested

The workflows have been used within Firefly.Backbone.Transport

## Type of change

<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->

- [ ] bug fix
- [x] new feature
- [ ] modification
- [ ] breaking change
- [ ] non-functional

## Checklist

<!-- [ ] are checkboxes in github, place an x in it like [x] to mark them as checked -->

- [ ] I have added tests to cover my changes
- [ ] Existing tests pass
- [x] Docs updated (where applicable)

